### PR TITLE
perf: optimize sqlite and batch processing (#1)

### DIFF
--- a/cmd/blockqueue/http.go
+++ b/cmd/blockqueue/http.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os/signal"
+	"runtime"
 	"syscall"
 	"time"
 
@@ -108,10 +109,18 @@ func (h *Http) Run(ctx context.Context, args []string) error {
 	}
 
 	engine := nbhttp.NewEngine(nbhttp.Config{
-		Network: "tcp",
-		Addrs:   []string{":" + cfg.Http.Port},
-		Handler: mux,
-		IOMod:   nbhttp.IOModNonBlocking,
+		Network:                 "tcp",
+		Addrs:                   []string{":" + cfg.Http.Port},
+		Handler:                 mux,
+		IOMod:                   nbhttp.IOModNonBlocking,
+		ReleaseWebsocketPayload: true,
+		MaxLoad:                 2000000,
+		MaxBlockingOnline:       300000,
+		KeepaliveTime:           time.Second * 300,
+		LockListener:            false,
+		ReadBufferSize:          32 * 1024,
+		MaxWriteBufferSize:      0,
+		NPoller:                 runtime.NumCPU() * 2,
 	})
 
 	signal.Notify(shutdown, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)

--- a/pkg/sqlite/sqlite.go
+++ b/pkg/sqlite/sqlite.go
@@ -1,7 +1,8 @@
 package sqlite
 
 import (
-	"fmt"
+	"strconv"
+	"time"
 
 	"github.com/jmoiron/sqlx"
 	_ "github.com/mattn/go-sqlite3"
@@ -15,21 +16,38 @@ type Config struct {
 	BusyTimeout int
 }
 
-func New(dbName string, config Config) (*SQLite, error) {
-	db, err := sqlx.Connect("sqlite3",
-		fmt.Sprintf(
-			"file:%s?_synchronous=normal&_journal_mode=wal&busy_timeout=%d",
-			dbName,
-			config.BusyTimeout,
-		),
-	)
+func New(filename string, cfg Config) (*SQLite, error) {
+	conn, err := sqlx.Connect("sqlite3", filename+"?_journal=WAL&_busy_timeout="+strconv.Itoa(cfg.BusyTimeout)+"&cache=shared")
 	if err != nil {
-		return &SQLite{}, err
+		return nil, err
 	}
 
-	return &SQLite{
-		Database: db,
-	}, nil
+	// Optimized connection pool settings - scale better with both low and high concurrency
+	conn.SetMaxOpenConns(35) // Increased from 25 for better low concurrency performance
+	conn.SetMaxIdleConns(15) // Increased from 10 for better reuse at low concurrency
+	conn.SetConnMaxLifetime(time.Hour)
+	conn.SetConnMaxIdleTime(10 * time.Minute) // Add explicit idle timeout
+
+	// Execute pragmas for better performance with adaptive settings
+	pragmas := []string{
+		"PRAGMA journal_mode = WAL",
+		"PRAGMA synchronous = NORMAL", // Keep NORMAL for reliability
+		"PRAGMA cache_size = 20000",   // Increased to 20MB for better caching
+		"PRAGMA temp_store = MEMORY",
+		"PRAGMA mmap_size = 134217728",     // 128MB mmap (increased for better read performance)
+		"PRAGMA page_size = 8192",          // Larger page size for better sequential reads
+		"PRAGMA busy_timeout = 5000",       // Consistent timeout
+		"PRAGMA wal_autocheckpoint = 1000", // Checkpoint WAL after 1000 pages
+	}
+
+	for _, pragma := range pragmas {
+		_, err = conn.Exec(pragma)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &SQLite{Database: conn}, nil
 }
 
 func (sqlite *SQLite) Conn() *sqlx.DB {


### PR DESCRIPTION
## Problem Statement
During my testing I couldn't get the claimed RPS in my Windows machine using WSL2. So I take a look at what I can do to improve the throughput in this machine. I was thinking this is due to the system specs and configuration. The assumption was right, after improving some codes I got doubled the result on M1 MAC which reach 30K RPS while its resulting 15K RPS in WSL2.

## Summary
This PR significantly improves BlockQueue's performance, achieving 15K (wsl2) and 30K (m1) requests per second (RPS) with zero failures under high load.

more detailed description my my thought process can be seen https://github.com/riez/blockqueue/pull/1
